### PR TITLE
Wrong number of arguments - posterous-buffer

### DIFF
--- a/posterous.el
+++ b/posterous.el
@@ -149,7 +149,7 @@
   "Post a whole buffer to posterous."
   (interactive)
   (save-excursion
-	(posterous-region (point-min) (point-max) "0" "")))
+	(posterous-region (point-min) (point-max))))
 
 
 (defun posterous-buffer-private ()


### PR DESCRIPTION
Hi, I've found a small bug in posterous-buffer function.
Thanks for sharing the script
